### PR TITLE
inner_hits added to hit structure

### DIFF
--- a/lib/coresearch.go
+++ b/lib/coresearch.go
@@ -211,6 +211,7 @@ type Hit struct {
 	Explanation *Explanation     `json:"_explanation,omitempty"`
 	Highlight   *Highlight       `json:"highlight,omitempty"`
 	Sort        []interface{}    `json:"sort,omitempty"`
+	InnerHits   *json.RawMessage `json:"inner_hits,omitempty"`
 }
 
 func (hit Hit) GetField(fieldName string) (interface{}, error) {


### PR DESCRIPTION
Adds `inner_hits` which elasticsearch may return in the response
